### PR TITLE
Added pronouns as an argument to the update user mutation

### DIFF
--- a/app/graphql/mutations/update_user.rb
+++ b/app/graphql/mutations/update_user.rb
@@ -11,6 +11,7 @@ module Mutations
     argument :last_name, String, required: false
     argument :email, String, required: false
     argument :password, String, required: false
+    argument :pronouns, String, required: false
     argument :user_type, Integer, required: false
     argument :company, String, required: false
 

--- a/app/graphql/mutations/update_user.rb
+++ b/app/graphql/mutations/update_user.rb
@@ -12,6 +12,7 @@ module Mutations
     argument :email, String, required: false
     argument :password, String, required: false
     argument :pronouns, String, required: false
+    argument :display_name, String, required: false
     argument :user_type, Integer, required: false
     argument :company, String, required: false
 


### PR DESCRIPTION
I was testing our mutations in Postman and noticed the way we had it set up you were not able to update a users pronouns. I just had to add one line in the arguments in the update user mutation to include pronouns.